### PR TITLE
Исправлено некорректное регулярное выражение

### DIFF
--- a/src/js/injection_scripts/video_info.js
+++ b/src/js/injection_scripts/video_info.js
@@ -41,7 +41,7 @@
         dictionary["episode_id"] = match[5];
     }
     dictionary["film_id"] = match[2];
-    dictionary["quality"] = CDNPlayer.api('quality').match(/\d*p(\sUltra)?/)[0];
-    dictionary["qualities"] = CDNPlayer.api('qualities').map((item) => item.match(/\d*p(\sUltra)?/)[0]);
+    dictionary["quality"] = CDNPlayer.api('quality').match(/\d*(?:(?:K)|(?:p(?:\sUltra)?))/)[0];
+    dictionary["qualities"] = CDNPlayer.api('qualities').map((item) => item.match(/\d*(?:(?:K)|(?:p(?:\sUltra)?))/)[0]);
     thisScript.dataset.result = JSON.stringify(dictionary);
 })();


### PR DESCRIPTION
Close #1 
В редких случаях когда в списке с качеством было доступно качество в 2К или 4К, регулярное выражение не могло корректно обработать эту строку и падало с ошибкой.